### PR TITLE
De-dupe alias and code objects. (Fixes #15)

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,6 @@ var codes = exports.code = exports.codes = {
   'down': 40,
   'insert': 45,
   'delete': 46,
-  'windows': 91,
   'command': 91,
   'right click': 93,
   'numpad *': 106,
@@ -88,20 +87,18 @@ var codes = exports.code = exports.codes = {
   '\\': 220,
   ']': 221,
   "'": 222,
-  '⇧': 16,
-  '⌥': 18,
-  '⌃': 17,
-  '⌘': 91,
 }
 
 // Helper aliases
 
 var aliases = exports.aliases = {
-  'shift': 16,
+  'windows': 91,
+  '⇧': 16,
+  '⌥': 18,
+  '⌃': 17,
+  '⌘': 91,
   'ctl': 17,
-  'ctrl': 17,
   'control': 17,
-  'alt': 18,
   'option': 18,
   'pause': 19,
   'break': 19,

--- a/test/keycode.js
+++ b/test/keycode.js
@@ -91,3 +91,8 @@ it('exposes keycode/name maps', function() {
   }
 })
 
+it('should return shift, ctrl, and alt for 16, 17, and 18', function() {
+  assert.strictEqual(keycode(16), 'shift')
+  assert.strictEqual(keycode(17), 'ctrl')
+  assert.strictEqual(keycode(18), 'alt')
+})


### PR DESCRIPTION
Original issue: https://github.com/timoxley/keycode/issues/15

I think the main back-compat impact is that the mac-specific symbols introduced in https://github.com/timoxley/keycode/pull/13 are now no longer reverse-mapped into `names` as the canonical name which seemed like it would break on non-mac platforms. However, those symbols are still present in `codes` so forward lookup for those symbols should still work.