### PR TITLE
Map 'meta' => 91, move 'command' to aliases

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ var codes = exports.code = exports.codes = {
   'down': 40,
   'insert': 45,
   'delete': 46,
-  'command': 91,
+  'meta': 91,
   'right click': 93,
   'numpad *': 106,
   'numpad +': 107,
@@ -92,6 +92,7 @@ var codes = exports.code = exports.codes = {
 // Helper aliases
 
 var aliases = exports.aliases = {
+  'command': 91,
   'windows': 91,
   '⇧': 16,
   '⌥': 18,
@@ -137,8 +138,13 @@ for (i = 0; i < 10; i++) codes['numpad '+i] = i + 96
 
 var names = exports.names = exports.title = {} // title for backward compat
 
+var canonicalCodes = exports._canonicalCodes = {} // for internal use
+
 // Create reverse mapping
-for (i in codes) names[codes[i]] = i
+for (i in codes) {
+  names[codes[i]] = i
+  canonicalCodes[i] = codes[i]
+}
 
 // Add aliases
 for (var alias in aliases) {

--- a/test/keycode.js
+++ b/test/keycode.js
@@ -96,3 +96,20 @@ it('should return shift, ctrl, and alt for 16, 17, and 18', function() {
   assert.strictEqual(keycode(17), 'ctrl')
   assert.strictEqual(keycode(18), 'alt')
 })
+
+it('should not have mapping collisions in canonical codes', function() {
+  var dedupe = {}
+  var canon = keycode._canonicalCodes
+  for (var key in canon) {
+    var val = canon[key]
+    var isDupe = dedupe[val]
+    var dupeKey, dupeVal
+    if (isDupe) {
+      dupeKey = isDupe.key
+      dupeVal = isDupe.val
+    }
+    assert.ok(!isDupe, 'mapping conflict in canonical codes: ' + key + ' => ' + val + ', ' + dupeKey + ' => ' + dupeVal)
+    dedupe[val] = {key:key,val:val}
+  }
+})
+


### PR DESCRIPTION
I realize this is a compat break but if a major version is being bumped (https://github.com/timoxley/keycode/pull/16#issuecomment-72606577) maybe this would be a good time to add it?

Since browsers generify the ‘command’ and ‘windows’ keys to both be called ‘metaKey’ on event objects, it seems appropriate to do that here too and have ‘command’ and ‘windows’ be aliases. Also expose a ‘_canonicalCodes’ object and test it for duplicates as a sanity check.