### PR TITLE
Trailing comma causes issues with some browsers

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ var codes = exports.code = exports.codes = {
   '[': 219,
   '\\': 220,
   ']': 221,
-  "'": 222,
+  "'": 222
 }
 
 // Helper aliases


### PR DESCRIPTION
I'm using this project with google closure compiler, and it won't compile because of the trailing comma (removed in this commit).