### PR TITLE
Add TypeScript definitions

### DIFF
--- a/keycode.d.ts
+++ b/keycode.d.ts
@@ -1,0 +1,22 @@
+declare namespace Keycode {
+    interface CodesMap {
+        [key: string]: number;
+    }
+    
+    interface KeycodeStatic {
+        (event: Event): string;
+        (keycode: number): string;
+        (name: string): number;
+        code: CodesMap;
+        codes: CodesMap;
+        aliases: CodesMap;
+        names: CodesMap;
+        title: CodesMap;
+    }
+}
+
+declare var keycode: Keycode.KeycodeStatic;
+
+declare module "keycode" {
+    export = keycode;
+}

--- a/package.json
+++ b/package.json
@@ -34,5 +34,6 @@
     "keyname",
     "keypress"
   ],
-  "author": "Tim Oxley <secoif@gmail.com>"
+  "author": "Tim Oxley <secoif@gmail.com>",
+  "typings": "./keycode.d.ts"
 }


### PR DESCRIPTION
usage: 

```ts
import * as keycode from 'keycode';

document.addEventListener('keydown', function(e) {
  console.log("You pressed", keycode(e));
});

const code: number = keycode('esc');
const name: string = keycode(27);
```

closes: #26