### PR TITLE
Add method keycode.isEventKey

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -81,6 +81,21 @@ del delete
 spc space
 ```
 
+## keycode.isEventKey(event: Event, nameOrCode: String | Number)
+
+Tests if an keyboard event against a given name or keycode.
+Will return `true` if the event matches the given name or keycode, `false` otherwise.
+
+```js
+// assume event is an keydown event with key 'enter'
+keycode.isEventKey(event, 'enter') // => true
+keycode.isEventKey(event, 'down') // => false
+
+keycode.isEventKey(event, 13) // => true
+keycode.isEventKey(event, 40) // => false
+```
+
+
 ## Maps
 
 Key code/name maps are available directly as `keycode.codes` and `keycode.names` respectively.

--- a/index.d.ts
+++ b/index.d.ts
@@ -140,4 +140,5 @@ declare interface Keycode {
   codes: CodesMap;
   aliases: AliasesMap;
   names: InverseCodesMap;
+  isEventKey: (event: Event, nameOrCode: number | string) => boolean;
 }

--- a/index.js
+++ b/index.js
@@ -39,6 +39,7 @@ function keyCode(searchInput) {
 /**
  * Compares a keyboard event with a given keyCode or keyName.
  *
+ * @param {Event} event Keyboard event that should be tested
  * @param {Mixed} keyCode {Number} or keyName {String}
  * @return {Boolean}
  * @api public

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@
  * @api public
  */
 
-exports = module.exports = function(searchInput) {
+function keyCode(searchInput) {
   // Keyboard Events
   if (searchInput && 'object' === typeof searchInput) {
     var hasKeyCode = searchInput.which || searchInput.keyCode || searchInput.charCode
@@ -35,6 +35,34 @@ exports = module.exports = function(searchInput) {
 
   return undefined
 }
+
+/**
+ * Compares a keyboard event with a given keyCode or keyName.
+ *
+ * @param {Mixed} keyCode {Number} or keyName {String}
+ * @return {Boolean}
+ * @api public
+ */
+keyCode.isEventKey = function isEventKey(event, nameOrCode) {
+  if (event && 'object' === typeof event) {
+    var keyCode = event.which || event.keyCode || event.charCode
+    if (keyCode === null || keyCode === undefined) { return false; }
+    if (typeof nameOrCode === 'string') {
+      // check codes
+      var foundNamedKey = codes[nameOrCode.toLowerCase()]
+      if (foundNamedKey) { return foundNamedKey === keyCode; }
+    
+      // check aliases
+      var foundNamedKey = aliases[nameOrCode.toLowerCase()]
+      if (foundNamedKey) { return foundNamedKey === keyCode; }
+    } else if (typeof nameOrCode === 'number') {
+      return nameOrCode === keyCode;
+    }
+    return false;
+  }
+}
+
+exports = module.exports = keyCode;
 
 /**
  * Get by name

--- a/test/keycode.js
+++ b/test/keycode.js
@@ -97,34 +97,34 @@ it('should return shift, ctrl, and alt for 16, 17, and 18', function() {
   assert.strictEqual(keycode(18), 'alt')
 })
 
-describe('isEventKey', () => {
+describe('isEventKey', function() {
   
-  it('should allow to compare events to their names', () => {
-    const event = { which: 13, keyCode: 13, charCode: 13 };
+  it('should allow to compare events to their names', function() {
+    var event = { which: 13, keyCode: 13, charCode: 13 };
     assert.strictEqual(keycode.isEventKey(event, 'enter'), true);
     assert.strictEqual(keycode.isEventKey(event, 'down'), false);
   });
   
-  it('should allow to compare events to their names (case insensitive)', () => {
-    const event = { which: 13, keyCode: 13, charCode: 13 };
+  it('should allow to compare events to their names (case insensitive)', function() {
+    var event = { which: 13, keyCode: 13, charCode: 13 };
     assert.strictEqual(keycode.isEventKey(event, 'eNtER'), true);
     assert.strictEqual(keycode.isEventKey(event, 'dOWN'), false);
   });
   
-  it('should return false if a ', () => {
-    const event = { which: 13, keyCode: 13, charCode: 13 };
+  it('should return false if a ', function() {
+    var event = { which: 13, keyCode: 13, charCode: 13 };
     assert.strictEqual(keycode.isEventKey(event, 'eNtER'), true);
     assert.strictEqual(keycode.isEventKey(event, 'dOWN'), false);
   });
   
-  it('should allow to compare events to their keyCodes)', () => {
-    const event = { which: 13, keyCode: 13, charCode: 13 };
+  it('should allow to compare events to their keyCodes)', function() {
+    var event = { which: 13, keyCode: 13, charCode: 13 };
     assert.strictEqual(keycode.isEventKey(event, 13), true);
     assert.strictEqual(keycode.isEventKey(event, 14), false);
   });
 
-  it('should not break when invalid key codes are entered, instead false should be returned', () => {
-    const event = { which: -1, keyCode: -1, charCode: -1 };
+  it('should not break when invalid key codes are entered, instead false should be returned', function() {
+    var event = { which: -1, keyCode: -1, charCode: -1 };
     assert.strictEqual(keycode.isEventKey(event, 'enter'), false);
     assert.strictEqual(keycode.isEventKey(event, 'down'), false);
   });

--- a/test/keycode.js
+++ b/test/keycode.js
@@ -96,3 +96,38 @@ it('should return shift, ctrl, and alt for 16, 17, and 18', function() {
   assert.strictEqual(keycode(17), 'ctrl')
   assert.strictEqual(keycode(18), 'alt')
 })
+
+describe('isEventKey', () => {
+  
+  it('should allow to compare events to their names', () => {
+    const event = { which: 13, keyCode: 13, charCode: 13 };
+    assert.strictEqual(keycode.isEventKey(event, 'enter'), true);
+    assert.strictEqual(keycode.isEventKey(event, 'down'), false);
+  });
+  
+  it('should allow to compare events to their names (case insensitive)', () => {
+    const event = { which: 13, keyCode: 13, charCode: 13 };
+    assert.strictEqual(keycode.isEventKey(event, 'eNtER'), true);
+    assert.strictEqual(keycode.isEventKey(event, 'dOWN'), false);
+  });
+  
+  it('should return false if a ', () => {
+    const event = { which: 13, keyCode: 13, charCode: 13 };
+    assert.strictEqual(keycode.isEventKey(event, 'eNtER'), true);
+    assert.strictEqual(keycode.isEventKey(event, 'dOWN'), false);
+  });
+  
+  it('should allow to compare events to their keyCodes)', () => {
+    const event = { which: 13, keyCode: 13, charCode: 13 };
+    assert.strictEqual(keycode.isEventKey(event, 13), true);
+    assert.strictEqual(keycode.isEventKey(event, 14), false);
+  });
+
+  it('should not break when invalid key codes are entered, instead false should be returned', () => {
+    const event = { which: -1, keyCode: -1, charCode: -1 };
+    assert.strictEqual(keycode.isEventKey(event, 'enter'), false);
+    assert.strictEqual(keycode.isEventKey(event, 'down'), false);
+  });
+
+});
+


### PR DESCRIPTION
`isEventKey` allows to compare an event with a keyCode or name. If both
match, the method returns `true`. Otherwise `false` is returned.