### PR TITLE
add new keycode for IE space

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,6 +14,7 @@ declare interface CodesMap {
   'caps lock': number;
   'esc': number;
   'space': number;
+  'Spacebar': number;
   'page up': number;
   'page down': number;
   'end': number;

--- a/index.js
+++ b/index.js
@@ -53,6 +53,7 @@ var codes = exports.code = exports.codes = {
   'caps lock': 20,
   'esc': 27,
   'space': 32,
+  'Spacebar': 32,
   'page up': 33,
   'page down': 34,
   'end': 35,

--- a/test/keycode.js
+++ b/test/keycode.js
@@ -34,6 +34,7 @@ it('is case insensitive', function() {
   assert.strictEqual(keycode('enter'), 13);
   assert.strictEqual(keycode('ENTER'), 13);
   assert.strictEqual(keycode('enTeR'), 13);
+  assert.strictEqual(keycode('Spacebar'), 32);
 })
 
 it('returns char code for strange chars', function() {


### PR DESCRIPTION
With the using keycode library with IE, there missed $event.key for space