### PR TITLE
fix: typings path

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,5 +35,5 @@
     "keypress"
   ],
   "author": "Tim Oxley <secoif@gmail.com>",
-  "typings": "./keycode.d.ts"
+  "typings": "./index.d.ts"
 }


### PR DESCRIPTION
While typescript can still resolve the issue it's still advisable to list the correct path according to https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html