### PR TITLE
Add alias for `command` on Firefox #50

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,7 +114,8 @@ var codes = exports.code = exports.codes = {
   '[': 219,
   '\\': 220,
   ']': 221,
-  "'": 222
+  "'": 222,
+  'command (firefox)': 224 
 }
 
 // Helper aliases
@@ -139,7 +140,8 @@ var aliases = exports.aliases = {
   'pgdn': 34,
   'ins': 45,
   'del': 46,
-  'cmd': 91
+  'cmd': 91,
+  'command': 224
 }
 
 /*!

--- a/test/keycode.js
+++ b/test/keycode.js
@@ -98,6 +98,11 @@ it('should return shift, ctrl, and alt for 16, 17, and 18', function() {
   assert.strictEqual(keycode(18), 'alt')
 })
 
+it('should return command code for all broswers', function() {
+  assert.strictEqual(keycode(91), 'left command');       //  Chrome and Safari
+  assert.strictEqual(keycode(224), 'command (firefox)'); //  Firefox
+})
+
 describe('isEventKey', function() {
   
   it('should allow to compare events to their names', function() {
@@ -118,7 +123,7 @@ describe('isEventKey', function() {
     assert.strictEqual(keycode.isEventKey(event, 'dOWN'), false);
   });
   
-  it('should allow to compare events to their keyCodes)', function() {
+  it('should allow to compare events to their keyCodes', function() {
     var event = { which: 13, keyCode: 13, charCode: 13 };
     assert.strictEqual(keycode.isEventKey(event, 13), true);
     assert.strictEqual(keycode.isEventKey(event, 14), false);
@@ -128,6 +133,11 @@ describe('isEventKey', function() {
     var event = { which: -1, keyCode: -1, charCode: -1 };
     assert.strictEqual(keycode.isEventKey(event, 'enter'), false);
     assert.strictEqual(keycode.isEventKey(event, 'down'), false);
+  });
+
+  it('should alias `command` in firefox', function() {
+    var event = { which: 224, keyCode: 224, charCode: 0 };
+    assert.strictEqual(keycode.isEventKey(event, 'command'), true);
   });
 
 });


### PR DESCRIPTION
I'ved added a new keymap, alias, and tests added to solve some cross browser problems.

Not sure how to solve this problem for for keycode() given the 1-to-1 mapping in the dictionary but keycode.isEventKey(event, 'command') will now work on Firefox.