### PR TITLE
Remove JS Doc comments that blow up in TypeScript 2.9 from index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,12 +65,6 @@ keyCode.isEventKey = function isEventKey(event, nameOrCode) {
 
 exports = module.exports = keyCode;
 
-/**
- * Get by name
- *
- *   exports.code['enter'] // => 13
- */
-
 var codes = exports.code = exports.codes = {
   'backspace': 8,
   'tab': 9,
@@ -157,12 +151,6 @@ for (i = 1; i < 13; i++) codes['f'+i] = i + 111
 
 // numpad keys
 for (i = 0; i < 10; i++) codes['numpad '+i] = i + 96
-
-/**
- * Get by code
- *
- *   exports.name[13] // => 'Enter'
- */
 
 var names = exports.names = exports.title = {} // title for backward compat
 


### PR DESCRIPTION
These JS Doc comments are causing my Angular production build to fail because my production build includes this code (this package is a dependency of a dependency of mine that is needed at compile time) and this code [does not compile due to a bug in TypeScript version 2.9](https://github.com/microsoft/TypeScript/issues/25935).

To resolve the issue, I have a custom script that removes the comments from this file so that my production build will pass. I would very much appreciate it if you would merge this PR and publish the changes on NPM so that I do not need to do this hacky thing during my deployments. I know that other people are having this same problem (even though I'm a bit late to the party).

If you want to keep these comments, can you please put them into a format that will compile for all TypeScript versions? It would be very much appreciated.