### PR TITLE
Add updated aliases for Arrow keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,6 +137,10 @@ var aliases = exports.aliases = {
   'spacebar': 32,
   'pgup': 33,
   'pgdn': 34,
+  'arrowleft': 37,
+  'arrowup': 38,
+  'arrowright': 39,
+  'arrowdown': 40,
   'ins': 45,
   'del': 46,
   'cmd': 91


### PR DESCRIPTION
The arrow keys used in this library are currently only relevant for older browser versions. Newer browsers include the prefix `Arrow` for each arrow key: https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values#navigation_keys